### PR TITLE
[Google OAuth] (Fix) wrong auth callback

### DIFF
--- a/google_oauth_setup.mdx
+++ b/google_oauth_setup.mdx
@@ -50,7 +50,7 @@ Add a `Authorized JavaScript origins` as:
 - `http://localhost:3000` for local or replace with `WEB_DOMAIN` if setting up for prod.
 
 Add a `Authorized redirect URIs` as:
-- `http://localhost:3000/auth/google/callback` for local setup or your `WEB_DOMAIN` if setting up for prod.
+- `http://localhost:3000/auth/oauth/callback` for local setup or your `WEB_DOMAIN` if setting up for prod.
 
 Click **CREATE** and save the Client ID and Client Secret for use in the next section
 


### PR DESCRIPTION
Fix oauth uri, which lead to `Error: redirect_uri_mismatch`