### PR TITLE
Add user and email scopes to SlackBot

### DIFF
--- a/slack_bot_setup.mdx
+++ b/slack_bot_setup.mdx
@@ -51,6 +51,8 @@ oauth_config:
       - channels:join
       - app_mentions:read
       - chat:write
+      - users:read
+      - users:read.email
 settings:
   event_subscriptions:
     bot_events:


### PR DESCRIPTION
This is needed to be able to fetch the user who is sending the question. That way if the bot is configured to respond to the user who sent the message or a set of users from a team, we can match them by email.